### PR TITLE
Refactor: flight booking api

### DIFF
--- a/app/Airline.php
+++ b/app/Airline.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Airline extends Model
+{
+    //
+}

--- a/app/Booking.php
+++ b/app/Booking.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Booking extends Model
+{
+    //
+}

--- a/app/City.php
+++ b/app/City.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class City extends Model
+{
+    //
+}

--- a/app/Country.php
+++ b/app/Country.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model
+{
+    //
+}

--- a/app/Destination.php
+++ b/app/Destination.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Destination extends Model
+{
+    //
+}

--- a/app/Flight.php
+++ b/app/Flight.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Flight extends Model
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/AirlinesController.php
+++ b/app/Http/Controllers/FLIGHT/AirlinesController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class AirlinesController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/BookingsController.php
+++ b/app/Http/Controllers/FLIGHT/BookingsController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class BookingsController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/CitiesController.php
+++ b/app/Http/Controllers/FLIGHT/CitiesController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class CitiesController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/CountriesController.php
+++ b/app/Http/Controllers/FLIGHT/CountriesController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class CountriesController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/DestinationsController.php
+++ b/app/Http/Controllers/FLIGHT/DestinationsController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DestinationsController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FLIGHT/FlightsController.php
+++ b/app/Http/Controllers/FLIGHT/FlightsController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\FLIGHT;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class FlightsController extends Controller
+{
+    //
+}

--- a/database/migrations/2020_09_17_075106_create_flights_table.php
+++ b/database/migrations/2020_09_17_075106_create_flights_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFlightsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('flights', function (Blueprint $table) {
+            $table->id();
+            $table->string('flight_number');
+            $table->dateTime('departure_time');
+            $table->dateTime('arrival_time');
+            $table->string('from');
+            $table->string('to');
+            $table->string('price');
+            $table->string('duration');
+            $table->string('airline_id');
+            $table->json('stops');
+            $table->string('class');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('flights');
+    }
+}

--- a/database/migrations/2020_09_17_075640_create_airlines_table.php
+++ b/database/migrations/2020_09_17_075640_create_airlines_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAirlinesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('airlines', function (Blueprint $table) {
+            $table->id();
+            $table->string('airline_name');
+            $table->string('country');
+            $table->string('airline_code');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('airlines');
+    }
+}

--- a/database/migrations/2020_09_17_075950_create_destinations_table.php
+++ b/database/migrations/2020_09_17_075950_create_destinations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDestinationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('destinations', function (Blueprint $table) {
+            $table->id();
+            $table->string('landing_airport');
+            $table->string('takeoff-airport');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('destinations');
+    }
+}

--- a/database/migrations/2020_09_17_080048_create_countries_table.php
+++ b/database/migrations/2020_09_17_080048_create_countries_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCountriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('countries', function (Blueprint $table) {
+            $table->id();
+            $table->string('country_name');
+            $table->string('country_code');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('countries');
+    }
+}

--- a/database/migrations/2020_09_17_080147_create_cities_table.php
+++ b/database/migrations/2020_09_17_080147_create_cities_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCitiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->id();
+            $table->string('city_name');
+            $table->string('city_code');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cities');
+    }
+}

--- a/database/migrations/2020_09_17_080427_create_bookings_table.php
+++ b/database/migrations/2020_09_17_080427_create_bookings_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBookingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->string('flight_id');
+            $table->string('return_id')->nullable();
+            $table->string('user_id');
+            $table->string('booking_status');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('bookings');
+    }
+}


### PR DESCRIPTION
I've refactored the initial code for the flight booking API. The initial idea of using the skyscanner API key wasn't a viable option for our needs:

1. I've created the initial API Migrations.
2. Initialized the Flight Booking API Controllers.
3. Initialized the API's Models 
This way my back-end colleagues can easily collaborate on the different bits of it. Kindly review.
